### PR TITLE
Ensure Ruby 1.8 compatibility

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -61,15 +61,16 @@ class Neovim < Formula
 
     cd "deps-build" do
       ohai "Building third-party dependencies."
-      system "cmake", "../third-party", *std_cmake_args, "-DUSE_BUNDLED_BUSTED=OFF"
+      system "cmake", "../third-party", "-DUSE_BUNDLED_BUSTED=OFF", *std_cmake_args
       system "make", "VERBOSE=1"
     end
 
     mkdir "build" do
       ohai "Building Neovim."
-      system "cmake", "..", *std_cmake_args,
+      system "cmake", "..",
              "-DDEPS_PREFIX=../deps-build/usr",
-             "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+             "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+             *std_cmake_args
       system "make", "VERBOSE=1", "install"
     end
   end


### PR DESCRIPTION
Put splatted arguments (*std_cmake_args) last to ensure Ruby 1.8 compatibility